### PR TITLE
typos

### DIFF
--- a/docs/powa-archivist/configuration.rst
+++ b/docs/powa-archivist/configuration.rst
@@ -7,7 +7,7 @@ The following configuration parameters (GUCs) are available in
 ``postgresql.conf``:
 
 powa.frequency:
-  Defaults to ``5 min``.
+  Defaults to ``5min``.
   Defines the frequency of the snapshots, in milliseconds or any time unit supported by PostgreSQL. Minimum 5s. You can use the usual postgresql time abbreviations. If not specified, the unit is seconds. Setting it to -1 will disable powa (powa will still start, but it won't collect anything anymore, and wont connect to the database).
 powa.retention:
   Defaults to ``1d`` (1 day)

--- a/docs/powa-archivist/development.rst
+++ b/docs/powa-archivist/development.rst
@@ -44,9 +44,9 @@ following functions:
     $PROC$ language plpgsql;
 
 **purge**:
-  This function will be called after every 10 aggregates, and is responsible for
+  This function will be called after every 10 aggregates and is responsible for
   purging stale data that should not be kept. The function should take the
-  'powa.retention' global parameter into account to prevent removing data that
+  `powa.retention` global parameter into account to prevent removing data that
   would still be valid.
 
   .. code-block:: plpgsql


### PR DESCRIPTION
typo, dont une importante puisque "5 min" est rejeté par pg