### PR TITLE
Add a quickstart documentation for RHEL / CentOS using the PGDG rpm packages

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -104,11 +104,11 @@ Again, for example for PostgreSQL 9.6 on CentOS 7 :
 
     yum install https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-7-x86_64/pgdg-centos96-9.6-3.noarch.rpm
 
-You also need to install the EPEL repo package to install the required Python dependencies :
+For RHEL / CentOS 6, you may need to install the EPEL repository.
 
 .. code-block:: bash
 
-    yum install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+    yum install https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
 
 This let's you install the `powa_96-web` RPM package :
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -83,6 +83,19 @@ Create the required extensions in this database :
     CREATE EXTENSION pg_qualstats;
     CREATE EXTENSION pg_stat_kcache;
 
+One last step is to create a role that has superuser privileges and is able to
+login to the cluster (use your own credentials) :
+
+.. code-block:: bash
+
+    psql -c "CREATE ROLE powa SUPERUSER LOGIN PASSWORD 'powa'"
+
+The Web UI requires you to log in with a PostgreSQL role that has superuser
+privileges as only a superuser can access to the query text in PostgreSQL, PoWA
+follows the same principle. Also, PoWA has to install the `hypopg` extension in
+order to check the suggested indexes are efficient, in any database of the
+PostgreSQL cluster.
+
 PoWA is now up and running on the PostgreSQL-side. You still need to set-up the
 Web interface in order to access your history.  Also, by default,
 powa-archivist stores history for 1 day and takes a snapshot every 5 minutes.
@@ -141,6 +154,8 @@ Then, run powa-web:
 
   powa-web
 
+You can now access to the Web UI by accessing the service throught the port 8888,
+use the role created earlier in PostgreSQL to connect to the UI.
 
 
 Build and install PoWA from the sources

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -7,9 +7,144 @@ Quickstart
 
   The current version of PoWA is designed for PostgreSQL 9.4 and later. If you want to use PoWA on PostgreSQL < 9.4, please use the `1.x series <http://powa.readthedocs.io/en/REL_1_STABLE/>`_
 
+Install PoWA-archivist on the PostgreSQL instance on RHEL / CentOS
+******************************************************************
 
-Install PoWA-archivist on the PostgreSQL instance
-*************************************************
+Prerequisites
+-------------
+
+Install the PGDG repo RPMs according to the PostgreSQL version and OS version you're using, take the package from
+https://yum.postgresql.org/repopackages.php
+
+For example for PostgreSQL 9.6 on CentOS 7 :
+
+.. code-block:: bash
+
+    yum install https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-7-x86_64/pgdg-centos96-9.6-3.noarch.rpm
+
+
+You will also need the PostgreSQL contrib package to provide `pg_stat_statements` :
+
+.. code-block:: bash
+
+    yum install postgresql96-contrib
+
+You also need a working PostgreSQL cluster.
+
+
+Installation
+------------
+
+Now, you can simply install the packages provided by the PGDG repository, for example for PostgreSQL 9.6 :
+
+.. code-block:: bash
+
+    yum install powa_96 pg_qualstats96 pg_stat_kcache96 hypopg_96
+
+
+Then add the required modules to `shared_preload_libraries` :
+
+.. code-block:: ini
+
+    shared_preload_libraries='pg_stat_statements,powa,pg_stat_kcache,pg_qualstats'
+
+Now restart PostgreSQL. Under RHEL / CentOS 6 :
+
+.. code-block:: bash
+
+    /etc/init.d/postgresql-9.6 restart
+
+Under RHEL / CentOS 7 :
+
+.. code-block:: bash
+
+    systemctl restart postgresql-9.6
+
+
+Switch to the `postgres` user in your shell :
+
+.. code-block:: bash
+
+    su - postgres
+
+Log-in to the PostgreSQL instance and create a `powa` database :
+
+.. code-block:: bash
+
+    psql postgres -c "CREATE DATABASE powa"
+
+Create the required extensions in this database :
+
+.. code-block:: sql
+
+    CREATE EXTENSION pg_stat_statements;
+    CREATE EXTENSION btree_gist;
+    CREATE EXTENSION powa;
+    CREATE EXTENSION pg_qualstats;
+    CREATE EXTENSION pg_stat_kcache;
+
+PoWA is now up and running on the PostgreSQL-side. You still need to set-up the
+Web interface in order to access your history.  Also, by default,
+powa-archivist stores history for 1 day and takes a snapshot every 5 minutes.
+This default settings can be changed easily afterwards.
+
+Install the Web UI
+------------------
+
+You can install the web-client on any server you like. The only requirement is
+that the web-client can connect to the previously set-up PostgreSQL cluster.
+
+If you're setting up PoWA on another server, you have to install the PGDG repo
+package again. This is required to install the `powa_96-web` package and some
+dependencies.
+
+Again, for example for PostgreSQL 9.6 on CentOS 7 :
+
+.. code-block:: bash
+
+    yum install https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-7-x86_64/pgdg-centos96-9.6-3.noarch.rpm
+
+You also need to install the EPEL repo package to install the required Python dependencies :
+
+.. code-block:: bash
+
+    yum install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+
+This let's you install the `powa_96-web` RPM package :
+
+.. code-block:: bash
+
+    yum install powa_96-web
+
+Modify the `/etc/powa-web.conf` config-file to tell the UI how to connect to
+your freshly installed PoWA database. Of course, change the given cookie to
+something from your own. For example to connect to the local instance throught
+`localhost` :
+
+.. code-block:: json
+
+  servers={
+    'main': {
+      'host': 'localhost',
+      'port': '5432',
+      'database': 'powa'
+    }
+  }
+  cookie_secret="SUPERSECRET_THAT_YOU_SHOULD_CHANGE"
+
+Don't forget to let the Web-server connect to the database, edit your
+`pg_hba.conf` accordingly.
+
+Then, run powa-web:
+
+.. code-block:: bash
+
+  powa-web
+
+
+
+Build and install PoWA from the sources
+***************************************
 
 
 Prerequisites

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -132,7 +132,7 @@ something from your own. For example to connect to the local instance throught
   }
   cookie_secret="SUPERSECRET_THAT_YOU_SHOULD_CHANGE"
 
-Don't forget to let the Web-server connect to the database, edit your
+Don't forget to let the Web-server connect to the PostgreSQL cluster, edit your
 `pg_hba.conf` accordingly.
 
 Then, run powa-web:


### PR DESCRIPTION
Following some customer comments, it is necessary to clarify that PoWA is fully packaged for RHEL / CentOS systems.
